### PR TITLE
Fixed format error for plot_confusion_matrix when type is float

### DIFF
--- a/src/secml/figure/_plots/c_plot_metric.py
+++ b/src/secml/figure/_plots/c_plot_metric.py
@@ -316,7 +316,7 @@ class CPlotMetric(CPlot):
         plt.setp(self._sp.get_xticklabels(), rotation=45,
                  ha="right", rotation_mode="anchor")
 
-        fmt = '%.2f' if normalize else 'd'
+        fmt = '.2f' if normalize else 'd'
 
         if colorbar is True:
             from mpl_toolkits.axes_grid1 import make_axes_locatable


### PR DESCRIPTION
```
fig.sp.plot_confusion_matrix(y_true, y_pred, normalize=True)
```
raise a "ValueError: Invalid format specifier" since the format specified is not correct.